### PR TITLE
STEP.14

### DIFF
--- a/http/coupon.http
+++ b/http/coupon.http
@@ -2,6 +2,14 @@
 GET http://localhost:8080/api/coupons
 Content-Type: application/json
 
+### 쿠폰 재고 레디스에 적재
+POST http://localhost:8080/api/coupons/issued
+Content-Type: application/json
+
+{
+  "couponId": 2,
+  "quantity": 10
+}
 
 ### 유효한 유저로 쿠폰 다운로드
 POST http://localhost:8080/api/coupons/download
@@ -9,7 +17,7 @@ Content-Type: application/json
 
 {
   "userId": 1,
-  "couponId": 1
+  "couponId": 2
 }
 
 

--- a/src/main/java/kr/hhplus/be/server/common/error/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/common/error/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     COUPON_ALREADY_DOWNLOAD(400, "C004", "발급된 쿠폰입니다."),
     COUPON_USE_FAILED(400, "C005", "쿠폰 사용 처리에 실패하였습니다."),
     COUPON_IS_EXPIRED(400, "C006", "만료된 쿠폰입니다."),
+    COUPON_NOT_ISSUED(400, "C007", "재고가 존재하지 않는 쿠폰입니다."),
 
     // 주문
     ORDER_NOT_FOUND(404, "O001", "주문을 조회할 수 없습니다."),

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package kr.hhplus.be.server.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer()); // String 값으로 저장
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/repository/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/repository/CouponRepository.java
@@ -18,5 +18,7 @@ public interface CouponRepository {
 
     Coupon saveCoupon(Coupon coupon);
 
-    UserCoupon getMyUserCoupon(long l, long l1);
+    UserCoupon getMyUserCoupon(long userId, long couponId);
+
+    int getUserCouponCount(long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponInventoryService.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/service/CouponInventoryService.java
@@ -1,0 +1,97 @@
+package kr.hhplus.be.server.coupon.domain.service;
+
+import jakarta.annotation.PostConstruct;
+import kr.hhplus.be.server.common.error.CustomExceptionHandler;
+import kr.hhplus.be.server.common.error.ErrorCode;
+import kr.hhplus.be.server.coupon.domain.repository.CouponRepository;
+import kr.hhplus.be.server.coupon.presentation.dto.CouponIssuedRequestDTO;
+import kr.hhplus.be.server.coupon.presentation.dto.UserCouponResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+public class CouponInventoryService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final CouponRepository couponRepository;
+
+    private DefaultRedisScript<Long> decrementScript;
+
+    @Autowired
+    public CouponInventoryService(RedisTemplate<String, String> redisTemplate, CouponRepository couponRepository) {
+
+        this.redisTemplate = redisTemplate;
+        this.couponRepository = couponRepository;
+    }
+
+    @PostConstruct
+    public void init() {
+
+        decrementScript = new DefaultRedisScript<>();
+
+        String script = "local current = redis.call('GET', KEYS[1]) " +
+                "if not current then return -1 end " +
+                "current = tonumber(current) " +
+                "if not current then return -2 end " +
+                "if current > 0 then " +
+                "   redis.call('DECR', KEYS[1]) " +
+                "   return 1 " +
+                "else " +
+                "   return 0 " +
+                "end";
+
+        decrementScript.setScriptText(script);
+        decrementScript.setResultType(Long.class);
+    }
+
+    public boolean processCouponDownload(long couponId, long userId) {
+
+        String issuedKey = "coupon_issued:" + couponId;
+        String inventoryKey = "coupon_inventory:" + couponId;
+        String strUserId = String.valueOf(userId);
+
+        // 이미 발급받은 사용자인지 확인 (set에 사용자 ID가 존재하면 이미 발급된 것)
+        Boolean isMember = redisTemplate.opsForSet().isMember(issuedKey, strUserId);
+        if (Boolean.TRUE.equals(isMember)) {
+            // 커스텀 예외를 던지거나, 원하는 방식으로 예외 처리
+            throw new CustomExceptionHandler(ErrorCode.COUPON_ALREADY_DOWNLOAD);
+        }
+
+        // 재고 감소를 위한 Lua 스크립트 실행
+        Long result = redisTemplate.execute(decrementScript, Collections.singletonList(inventoryKey));
+
+        // 원자적 연산 결과가 1이면 재고 감소 성공
+        if (result != null && result == 1) {
+            // 발급 성공 시, 발급받은 사용자 정보를 Redis에 기록
+            redisTemplate.opsForSet().add(issuedKey, strUserId);
+            return true;
+        }
+        return false;
+    }
+
+    public boolean issuedCouponQuantity(CouponIssuedRequestDTO couponIssuedRequestDTO) {
+        // 1. CouponRequestDTO에서 쿠폰 ID와 초기 재고 수량 추출
+        long couponId = couponIssuedRequestDTO.couponId();
+        int quantity = couponIssuedRequestDTO.quantity(); // 쿠폰 재고 수량
+        int userCouponCount = couponRepository.getUserCouponCount(couponId);
+
+        int resultQuantity = quantity - userCouponCount;
+
+        if(resultQuantity <= 0) {
+            throw new CustomExceptionHandler(ErrorCode.COUPON_NOT_ISSUED);
+        }
+        // 2. Redis에서 사용할 key 이름 설정
+        String inventoryKey = "coupon_inventory:" + couponId;
+
+        // 3. 쿠폰 재고를 Redis에 저장 (문자열로 저장)
+        redisTemplate.opsForValue().set(inventoryKey, String.valueOf(quantity));
+
+        return true;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/coupon/domain/service/UserCouponService.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/domain/service/UserCouponService.java
@@ -26,7 +26,7 @@ public class UserCouponService {
             throw new CustomExceptionHandler(ErrorCode.COUPON_ALREADY_DOWNLOAD);
         }
 
-        UserCoupon userCoupon = UserCoupon.createUserCoupon(couponRequest.userId(), couponRequest.couponId(), UserCouponType.N);
+        UserCoupon userCoupon = UserCoupon.createUserCoupon(couponRequest.couponId(), couponRequest.userId(), UserCouponType.N);
 
         UserCoupon resultUserCoupon = couponRepository.saveUserCoupon(userCoupon);
 

--- a/src/main/java/kr/hhplus/be/server/coupon/infrastructure/repository/UserCouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infrastructure/repository/UserCouponJpaRepository.java
@@ -8,4 +8,6 @@ public interface UserCouponJpaRepository extends JpaRepository<UserCoupon, Long>
     UserCoupon findByUserIdAndCouponId(long userId, long couponId);
 
     UserCoupon findByUserCouponId(long userCouponId);
+
+    int countByCouponId(long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/infrastructure/repositoryImpl/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/infrastructure/repositoryImpl/CouponRepositoryImpl.java
@@ -51,4 +51,9 @@ public class CouponRepositoryImpl implements CouponRepository {
         return userCouponJpaRepository.findByUserIdAndCouponId(userId, couponId);
     }
 
+    @Override
+    public int getUserCouponCount(long couponId) {
+        return userCouponJpaRepository.countByCouponId(couponId);
+    }
+
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/presentation/controller/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/presentation/controller/CouponController.java
@@ -1,12 +1,10 @@
 package kr.hhplus.be.server.coupon.presentation.controller;
 
+import kr.hhplus.be.server.coupon.domain.service.CouponInventoryService;
 import kr.hhplus.be.server.coupon.domain.service.CouponService;
 import kr.hhplus.be.server.coupon.domain.service.info.CouponInfo;
 import kr.hhplus.be.server.coupon.domain.service.info.CouponsInfo;
-import kr.hhplus.be.server.coupon.presentation.dto.CouponRequestDTO;
-import kr.hhplus.be.server.coupon.presentation.dto.CouponResponseDTO;
-import kr.hhplus.be.server.coupon.presentation.dto.UserCouponResponseDTO;
-import kr.hhplus.be.server.coupon.presentation.dto.CouponsResponseDTO;
+import kr.hhplus.be.server.coupon.presentation.dto.*;
 import kr.hhplus.be.server.coupon.presentation.usecase.CouponUsecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,6 +19,7 @@ public class CouponController implements CouponControllerDocs {
 
     private final CouponService couponService;
     private final CouponUsecase couponUsecase;
+    private final CouponInventoryService couponInventoryService;
 
     @GetMapping("/api/coupons")
     public ResponseEntity<List<CouponsResponseDTO>> getCoupons(
@@ -69,6 +68,15 @@ public class CouponController implements CouponControllerDocs {
         );
 
         return ResponseEntity.status(HttpStatus.OK).body(couponResponseDTO);
+    }
+
+    @PostMapping("/api/coupons/issued")
+    public ResponseEntity<Boolean> issuedCouponQuantity(
+            @RequestBody CouponIssuedRequestDTO couponIssuedRequestDTO) {
+
+        Boolean result = couponInventoryService.issuedCouponQuantity(couponIssuedRequestDTO);
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 
 }

--- a/src/main/java/kr/hhplus/be/server/coupon/presentation/dto/CouponIssuedRequestDTO.java
+++ b/src/main/java/kr/hhplus/be/server/coupon/presentation/dto/CouponIssuedRequestDTO.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.coupon.presentation.dto;
+
+
+public record CouponIssuedRequestDTO(
+        int quantity,
+        long couponId
+){
+}

--- a/src/test/java/kr/hhplus/be/server/coupon/presentation/controller/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/coupon/presentation/controller/CouponConcurrencyTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -18,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql("/couponData.sql")
 @SpringBootTest
-@ActiveProfiles("test")
+@ActiveProfiles({"test"})
 public class CouponConcurrencyTest {
 
     @Autowired
@@ -27,12 +28,23 @@ public class CouponConcurrencyTest {
     @Autowired
     private CouponRepository couponRepository;
 
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
     @Test
     @DisplayName("여러유저가 동시에 쿠폰을 발급할때 재고의 갯수만큼만 발급된다.")
     void couponDownloadTest() throws InterruptedException {
         // given
         long couponId = 1L; // couponData.sql에서 삽입된 쿠폰 ID
         int threadCount = 10; // 동시 요청 수
+        int initialInventory = 5; // 미리 적재할 쿠폰 재고
+
+        // 쿠폰 재고를 Redis에 미리 적재
+        String inventoryKey = "coupon_inventory:" + couponId;
+        String issuedKey = "coupon_issued:" + couponId;
+        redisTemplate.opsForValue().set(inventoryKey, String.valueOf(initialInventory));
+        // 이전 발급 내역이 남아있을 수 있으므로 삭제 (없으면 무시됨)
+        redisTemplate.delete(issuedKey);
 
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
@@ -44,7 +56,6 @@ public class CouponConcurrencyTest {
             executorService.submit(() -> {
                 try {
                     CouponRequestDTO couponRequestDTO = new CouponRequestDTO(userId, couponId);
-                    System.out.println("couponId = " + couponId);
                     couponController.couponDownload(couponRequestDTO);
                     successCount.incrementAndGet();
                 } catch (Exception ignored) {
@@ -58,12 +69,12 @@ public class CouponConcurrencyTest {
         latch.await(); // 모든 쓰레드가 작업을 완료할 때까지 대기
         executorService.shutdown();
 
-        System.out.println("쿠폰 재고 : "+couponRepository.getCoupon(couponId).getCouponQuantity());
         // then
         System.out.println("성공 횟수: " + successCount);
         System.out.println("실패 횟수: " + failCount);
 
         // 검증: 재고가 5개
+        assertThat(couponRepository.getUserCouponCount(couponId)).isEqualTo(5);
         assertThat(successCount.get()).isEqualTo(5); // 성공한 요청 수
         assertThat(failCount.get()).isEqualTo(5); // 실패한 요청 수
 


### PR DESCRIPTION
### **커밋 링크**
선착순 쿠폰 발급 로직 레디스로 변경 : 27bf76a538e48f2084b4910f9fc1379523c638a6

### **리뷰 포인트(질문)**

Lua 스크립트가 쿠폰 재고 차감과 유저 ID 등록을 동시에 원자적으로 처리하도록 작성된 방식에 대해 검토받고 싶습니다.
정확히 이런 방식을 사용을 현업에서도 하는 방향인지 궁금합니다

서비스를 따로두어서 기존에 비관적락을 사용하려고 한다면 해당 서비스 부분만 변경하도록 수정을 하려고 노력하였는데 
제 생각엔 이것이 확장성 있게 짠것이라 생각했지만 멘토링이후 이것또한 인터페이스로 가져올수 있다는 생각이 들었는데 혹시 이러한 생각의 방향이 맞는지 궁금합니다